### PR TITLE
Insteon LED Backlight support

### DIFF
--- a/HassBridge.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/HassBridge.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -92,12 +92,16 @@
     </Field>
 
     <Field id="create_battery_sensors" type="checkbox" defaultValue="false">
-        <Label>Create Battery Sensors:</Label>
+        <Label>Create Battery Sensors Default:</Label>
         <Description>(for battery powered devices)</Description>
     </Field>
     <Field id="insteon_battery_minutes_no_com" type="textfield" defaultValue="1440" visibleBindingId="create_battery_sensors" visibleBindingValue="true">
         <Label>Insteon Battery No Comm Minutes:</Label>
         <Description>The number of minutes since the last communication to mark the sensor as low battery</Description>
+    </Field>
+    <Field id="create_insteon_led_backlight_lights" type="checkbox" defaultValue="false">
+        <Label>Insteon LED Backlight Lights Default:</Label>
+        <Description>(Default for light entries in Home Assistant to control the LED Backlights)</Description>
     </Field>
 
     <Field id="variablesSeperator" type="separator"/>

--- a/HassBridge.indigoPlugin/Contents/Server Plugin/__init__.py
+++ b/HassBridge.indigoPlugin/Contents/Server Plugin/__init__.py
@@ -100,6 +100,10 @@ class Config(object):
         self.create_battery_sensors = pluginPrefs.get(
             u"create_battery_sensors",
             False)
+        self.create_insteon_led_backlight_lights = pluginPrefs.get(
+            u'create_insteon_led_backlight_lights',
+            False
+        )
 
         self.insteon_no_comm_minutes = int(pluginPrefs.get(
             u"insteon_battery_minutes_no_com", 1440))
@@ -135,6 +139,8 @@ class Config(object):
                 'devices' in self.customizations and \
                 dev.name in self.customizations['devices']:
             overrides = self.customizations['devices'][dev.name]
+        if overrides is None:
+            overrides = {}
         return overrides
 
 

--- a/HassBridge.indigoPlugin/Contents/Server Plugin/insteon/__init__.py
+++ b/HassBridge.indigoPlugin/Contents/Server Plugin/insteon/__init__.py
@@ -25,12 +25,14 @@ from .type_generators import \
     InsteonKeypadTypesGenerator, \
     InsteonInputOutputTypesGenerator, \
     InsteonRemoteTypesGenerator, \
-    InsteonBatteryPoweredSensorsTypeGenerator
+    InsteonBatteryPoweredSensorsTypeGenerator, \
+    InsteonLedBacklightTypeGenerator
 
 __all__ = [
     'InsteonDefaultTypesGenerator',
     'InsteonKeypadTypesGenerator',
     'InsteonInputOutputTypesGenerator',
     'InsteonRemoteTypesGenerator',
-    'InsteonBatteryPoweredSensorsTypeGenerator'
+    'InsteonBatteryPoweredSensorsTypeGenerator',
+    'InsteonLedBacklightTypeGenerator'
 ]

--- a/HassBridge.indigoPlugin/Contents/Server Plugin/insteon/type_generators.py
+++ b/HassBridge.indigoPlugin/Contents/Server Plugin/insteon/type_generators.py
@@ -26,9 +26,8 @@ from .command_processors import INSTEON_EVENTS
 from .devices import (
     InsteonBatteryStateSensor, InsteonBinarySensor,
     InsteonButtonActivityTracker, InsteonCover, InsteonFan,
-    InsteonKeypadButtonLight, InsteonLight, InsteonLock,
-    InsteonRemote, InsteonSensor,
-    InsteonSwitch)
+    InsteonKeypadButtonLight, InsteonLedBacklight, InsteonLight, InsteonLock,
+    InsteonRemote, InsteonSensor, InsteonSwitch)
 
 INSTEON_KEYPAD_8_BUTTON_MAP = {2: 'B', 3: 'C', 4: 'D', 5: 'E', 6: 'F', 7: 'G',
                                8: 'H'}
@@ -244,11 +243,20 @@ class InsteonBatteryPoweredSensorsTypeGenerator(object):
     @staticmethod
     def generate(dev, config, logger):
         devices = {}
-        if config.create_battery_sensors and \
-                str(dev.model) in ['Leak Sensor',
-                                   'Open/Close Sensor',
-                                   'Door Sensor',
-                                   'Motion Sensor (2844)']:
+
+        overrides = config.get_overrides_for_device(dev)
+        # pylint: disable=too-many-boolean-expressions
+        if str(dev.protocol).lower() == u'insteon' and \
+            str(dev.model) in ['Leak Sensor',
+                               'Open/Close Sensor',
+                               'Door Sensor',
+                               'Motion Sensor (2844)'] and \
+            (
+                (config.create_battery_sensors and
+                 'enable_battery_sensor' not in overrides) or
+                ('enable_battery_sensor' in overrides and
+                 overrides['enable_battery_sensor'] is True)
+            ):
             device = InsteonBatteryStateSensor(
                 dev,
                 config.customizations,
@@ -257,6 +265,34 @@ class InsteonBatteryPoweredSensorsTypeGenerator(object):
                 config.insteon_no_comm_minutes
             )
             devices[device.id] = device
+        return devices
+
+    @staticmethod
+    # pylint: disable=unused-argument
+    def is_bridgeable(dev):
+        return False
+
+
+class InsteonLedBacklightTypeGenerator(object):
+    @staticmethod
+    def generate(dev, config, logger):
+        devices = {}
+
+        overrides = config.get_overrides_for_device(dev)
+        if str(dev.protocol).lower() == u'insteon' and \
+            (
+                    (config.create_insteon_led_backlight_lights and
+                     'enable_led_backlight_light' not in overrides) or
+                    ('enable_led_backlight_light' in overrides and
+                     overrides['enable_led_backlight_light'] is True)
+            ):
+            firmware_version = int(dev.version)
+            if "KeypadLinc" in dev.model or (
+                    "SwitchLinc" in dev.model and firmware_version >= 0x38) \
+                    or "OutletLinc" in dev.model:
+                device = InsteonLedBacklight(dev, overrides, logger,
+                                             config.hass_discovery_prefix)
+                devices[device.id] = device
         return devices
 
     @staticmethod

--- a/HassBridge.indigoPlugin/Contents/Server Plugin/insteon/type_generators.py
+++ b/HassBridge.indigoPlugin/Contents/Server Plugin/insteon/type_generators.py
@@ -244,19 +244,11 @@ class InsteonBatteryPoweredSensorsTypeGenerator(object):
     def generate(dev, config, logger):
         devices = {}
 
-        overrides = config.get_overrides_for_device(dev)
-        # pylint: disable=too-many-boolean-expressions
-        if str(dev.protocol).lower() == u'insteon' and \
-            str(dev.model) in ['Leak Sensor',
-                               'Open/Close Sensor',
-                               'Door Sensor',
-                               'Motion Sensor (2844)'] and \
-            (
-                (config.create_battery_sensors and
-                 'enable_battery_sensor' not in overrides) or
-                ('enable_battery_sensor' in overrides and
-                 overrides['enable_battery_sensor'] is True)
-            ):
+        if config.create_battery_sensors and \
+                str(dev.model) in ['Leak Sensor',
+                                   'Open/Close Sensor',
+                                   'Door Sensor',
+                                   'Motion Sensor (2844)']:
             device = InsteonBatteryStateSensor(
                 dev,
                 config.customizations,

--- a/HassBridge.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HassBridge.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -59,7 +59,7 @@ from hassbridge import (
 from insteon import (
     InsteonDefaultTypesGenerator, InsteonKeypadTypesGenerator,
     InsteonInputOutputTypesGenerator, InsteonRemoteTypesGenerator,
-    InsteonBatteryPoweredSensorsTypeGenerator)
+    InsteonBatteryPoweredSensorsTypeGenerator, InsteonLedBacklightTypeGenerator)
 # pylint: disable=relative-import
 from variables import VariableDefaultTypesGenerator
 # pylint: disable=relative-import
@@ -533,6 +533,7 @@ class DeviceGeneratorFactory(object):
         InsteonInputOutputTypesGenerator,
         InsteonRemoteTypesGenerator,
         InsteonBatteryPoweredSensorsTypeGenerator,
+        InsteonLedBacklightTypeGenerator,
         ZWaveDefaultTypesGenerator,
         ZWaveBatteryPoweredSensorsTypeGenerator,
         VirtualDefaultTypesGenerator

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ devices:
     config_vars:
       device_class: safety
   Street Gate:
+    enable_battery_sensor: False
     config_vars:
       device_class: door
   West Side Gate:
@@ -121,6 +122,9 @@ devices:
   Garage Door:
     config_vars:
       device_class: garage
+  Some Insteon Switchlink:
+    enable_led_backlight_light: True
+    backlight_set_mechansim: swl        # this is the older protocol. default is kpl (newer command)   
 
 variables:                        
   front_door_state:                    # Indigo variable name
@@ -136,6 +140,33 @@ variables:
       device_class: window
  ```
 
+### Bridge Types
+The **bridge_type** in the main config of a device or variable customization can be set to allow you to override the 
+behavior of the Indigo device and how it is presented to Home Assistant.  This changes the mechanims used to talk to 
+the Indigo device when a command for it comes in from Home Assistant, so this may cause erratic behaviour.  This should 
+mainly be used when the default mapping by HassBridge is incorrect, and you want to force the correct mapping.
+
+#### Available Bridge Types
+| Bridge Types |  
+|:--------------------|  
+| InsteonBinarySensor |
+| InsteonCover |
+| InsteonFan |
+| InsteonLight |
+| InsteonLock |  
+| InsteonSensor |  
+| InsteonSwitch |  
+| VariableBinarySensor |
+| VariableSensor |
+| VirtualBinarySensor |
+| VirtualLight |
+| VirtualSwitch |
+| ZWaveBinarySensor |
+| ZWaveFan |
+| ZWaveLight |
+| ZWaveLock |
+| ZWaveSensor |
+| ZWaveSwitch |
 
 ## General Device Mapping
 | Indigo Device Class | Home Assistant Type |  

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ devices:
     config_vars:
       device_class: safety
   Street Gate:
-    enable_battery_sensor: False
     config_vars:
       device_class: door
   West Side Gate:
@@ -140,33 +139,6 @@ variables:
       device_class: window
  ```
 
-### Bridge Types
-The **bridge_type** in the main config of a device or variable customization can be set to allow you to override the 
-behavior of the Indigo device and how it is presented to Home Assistant.  This changes the mechanims used to talk to 
-the Indigo device when a command for it comes in from Home Assistant, so this may cause erratic behaviour.  This should 
-mainly be used when the default mapping by HassBridge is incorrect, and you want to force the correct mapping.
-
-#### Available Bridge Types
-| Bridge Types |  
-|:--------------------|  
-| InsteonBinarySensor |
-| InsteonCover |
-| InsteonFan |
-| InsteonLight |
-| InsteonLock |  
-| InsteonSensor |  
-| InsteonSwitch |  
-| VariableBinarySensor |
-| VariableSensor |
-| VirtualBinarySensor |
-| VirtualLight |
-| VirtualSwitch |
-| ZWaveBinarySensor |
-| ZWaveFan |
-| ZWaveLight |
-| ZWaveLock |
-| ZWaveSensor |
-| ZWaveSwitch |
 
 ## General Device Mapping
 | Indigo Device Class | Home Assistant Type |  


### PR DESCRIPTION
This adds support for adding a Home Assistant light to 
control the LED Backlight available on some Insteon 
switches and Keypanels.  It provided on, off, 
and brightness control.  Some Insteon switches do not 
seem to respond to this correctly but it should 
work overall.