### PR TITLE
Cleanup battery sensor creation

### DIFF
--- a/HassBridge.indigoPlugin/Contents/Server Plugin/insteon/type_generators.py
+++ b/HassBridge.indigoPlugin/Contents/Server Plugin/insteon/type_generators.py
@@ -244,11 +244,20 @@ class InsteonBatteryPoweredSensorsTypeGenerator(object):
     @staticmethod
     def generate(dev, config, logger):
         devices = {}
-        if config.create_battery_sensors and \
+
+        overrides = config.get_overrides_for_device(dev)
+        # pylint: disable=too-many-boolean-expressions
+        if str(dev.protocol).lower() == u'insteon' and \
                 str(dev.model) in ['Leak Sensor',
                                    'Open/Close Sensor',
                                    'Door Sensor',
-                                   'Motion Sensor (2844)']:
+                                   'Motion Sensor (2844)'] and \
+                (
+                    (config.create_battery_sensors and
+                     'enable_battery_sensor' not in overrides) or
+                    ('enable_battery_sensor' in overrides and
+                     overrides['enable_battery_sensor'] is True)
+                ):
             device = InsteonBatteryStateSensor(
                 dev,
                 config.customizations,

--- a/HassBridge.indigoPlugin/Contents/Server Plugin/zwave/type_generators.py
+++ b/HassBridge.indigoPlugin/Contents/Server Plugin/zwave/type_generators.py
@@ -85,7 +85,17 @@ class ZWaveBatteryPoweredSensorsTypeGenerator(object):
     @staticmethod
     def generate(dev, config, logger):
         devices = {}
-        if config.create_battery_sensors and dev.batteryLevel is not None:
+        overrides = config.get_overrides_for_device(dev)
+        # pylint: disable=too-many-boolean-expressions
+        if str(dev.protocol).lower() == u'zwave' and \
+            dev.batteryLevel is not None and \
+            (
+                    (config.create_battery_sensors and
+                     'enable_battery_sensor' not in overrides)
+                    or
+                    ('enable_battery_sensor' in overrides and
+                     overrides['enable_battery_sensor'] is True)
+            ):
             device = ZWaveBatteryStateSensor(dev,
                                              config.customizations,
                                              logger,

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ devices:
     config_vars:
       device_class: safety
   Street Gate:
+    enable_battery_sensor: False
     config_vars:
       device_class: door
   West Side Gate:


### PR DESCRIPTION
This allows the enable_battery_sensor config option to be set for a device and allows it to control individual devices support for the battery sensor device.